### PR TITLE
Implement more options

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        channel: [stable, beta, nightly]
+        channel: ["1.61.0", stable, nightly]
         os: [ubuntu, macos]
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
       matrix:
         arch: [i686, x86_64, aarch64]
         variant: [gnu, msvc]
-        channel: [stable, beta, nightly]
+        channel: ["1.61.0", stable, nightly]
         exclude:
           - arch: aarch64
             variant: gnu

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        channel: ["1.61.0", stable, nightly]
+        channel: ["1.62.1", stable, nightly]
         os: [ubuntu, macos]
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
       matrix:
         arch: [i686, x86_64, aarch64]
         variant: [gnu, msvc]
-        channel: ["1.61.0", stable, nightly]
+        channel: ["1.62.1", stable, nightly]
         exclude:
           - arch: aarch64
             variant: gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "fs_at"
 readme = "README.md"
 repository = "https://github.com/rbtcollins/fs_at.git"
-rust-version = "1.59.0"
+rust-version = "1.61.0"
 version = "0.0.1-alpha1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ conditions. For Unix these calls are readily available in the libc crate, but
 for Windows some more plumbing is needed. This crate provides a unified
 Rust-y interface to these calls.
 
+## MSRV policy
+
+I'll keep this compiling against older rusts as long as it is easy, but not at
+the expense of a lot of code golf, or past CVEs in old releases of dependencies.
+Currently MSRV is 1.62.
+
 ## Usage
 
 See the crate [docs](https://docs.rs/fs_at). But in short: use

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ when it is finished.
 
 PR's as normal on Github.
 
+Coverage - consider grcov.
+
+```rust
+export RUSTFLAGS="-Cinstrument-coverage"
+export LLVM_PROFILE_FILE="fs-at-%p-%m.profraw"
+cargo test && grcov . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o ./target/debug/cove
+rage/
+```
+
 ## Code of conduct
 
 Please note that this project is released with a Contributor Code of Conduct. By

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,12 +61,14 @@ pub enum OpenOptionsWriteMode {
     /// pointer (`seek(SeekFrom::Current(0))`) and then apply the result before
     /// the next read.
     ///
-    /// Most OSes make these writes atomically, such that different threads or
-    /// even processes can collaborate safely on a single file, as long as each
-    /// write call provides a full unit of data (e.g. a line, or a binary struct
-    /// etc). This can be done by building up the data to write, or using a
-    /// buffered writer that is large enough and calling flush after each unit
-    /// is complete.
+    /// Most OSes and filesystems make these writes atomically, such that
+    /// different threads or even processes can collaborate safely on a single
+    /// file, as long as each write call provides a full unit of data (e.g. a
+    /// line, or a binary struct etc). This can be done by building up the data
+    /// to write, or using a buffered writer that is large enough and calling
+    /// flush after each unit is complete.
+    ///
+    /// In particular NFS on Linux is documented as not providing atomic appends.
     ///
     /// ```no_compile
     /// use std::fs::OpenOptions;
@@ -137,7 +139,9 @@ impl OpenOptions {
     /// pathname, whether links or directories.
     ///
     /// This is performed by the OS as an atomic operation, providing safety
-    /// against TOCTOU conditions.
+    /// against TOCTOU conditions. Whether this will occur as an atomic
+    /// operation depends on the OS and filesystem in use. In particular NFS
+    /// versions below 3 do not support the needed operations for atomicity.
     ///
     /// Unlike the Rust stdlib, an options with write set to
     /// [`OpenOptionsWriteMode::None`] can still be used to create a new file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,20 @@ pub struct OpenOptions {
 }
 
 impl OpenOptions {
+    /// Sets the option for read access.
+    ///
+    /// This option, when true, will indicate that the file should be read-able if opened.
+    ///
+    /// ```no_compile
+    /// use fs_at::OpenOptions;
+    ///
+    /// let file = OpenOptions::default().read(true).open_at(parent, "foo");
+    /// ```
+    pub fn read(&mut self, read: bool) -> &mut Self {
+        self._impl.read(read);
+        self
+    }
+
     /// Set the option to create a new file when missing, while still opening
     /// existing files.
     pub fn create(&mut self, create: bool) -> &mut Self {
@@ -105,7 +119,7 @@ pub mod testsupport;
 mod tests {
     use std::{
         fs::{rename, File},
-        io::Result,
+        io::{Error, ErrorKind, Result},
         path::PathBuf,
     };
 
@@ -126,50 +140,166 @@ mod tests {
         Ok((tmp, parent_file, renamed_parent))
     }
 
-    #[test]
-    fn mkdirat_simple() -> Result<()> {
-        // mk a new dir
+    #[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
+    enum Op {
+        // Perform a mkdirat call
+        #[default]
+        MkDir,
+        // perform an open call on a file
+        OpenFile,
+        // perform an open call on a dir ? [should this be extension only?]
+        OpenDir,
+    }
+
+    #[derive(Default, Debug, Clone)]
+    struct Test<'a> {
+        pub create: bool,
+        pub read: bool,
+        pub op: Op,
+        pub err: Option<&'a Error>,
+    }
+
+    impl<'a> Test<'a> {
+        fn create(mut self, create: bool) -> Self {
+            self.create = create;
+            self
+        }
+
+        fn read(mut self, read: bool) -> Self {
+            self.read = read;
+            self
+        }
+
+        fn op(mut self, op: Op) -> Self {
+            self.op = op;
+            self
+        }
+
+        fn err(mut self, err: Option<&'a Error>) -> Self {
+            self.err = err;
+            self
+        }
+    }
+
+    fn _check_behaviour(test: Test, create_in_advance: bool, err: Option<&Error>) -> Result<()> {
+        eprintln!(
+            "testing op: {:?} create_in_advance: {}, err: {:?}",
+            test, create_in_advance, err
+        );
         let (_tmp, mut parent_file, renamed_parent) = setup()?;
-        let _child: File = OpenOptions::default().mkdir_at(&mut parent_file, "child")?;
+        let mut options = OpenOptions::default();
+
+        if create_in_advance {
+            match test.op {
+                Op::MkDir => {
+                    options.mkdir_at(&mut parent_file, "child")?;
+                }
+                Op::OpenDir => (),
+                Op::OpenFile => (),
+            }
+        }
+        if test.create {
+            options.create(true);
+        }
+        if test.read {
+            options.read(true);
+        }
+
+        let res = match test.op {
+            Op::MkDir => options.mkdir_at(&mut parent_file, "child"),
+            Op::OpenDir => unimplemented!(),
+            Op::OpenFile => options.open_at(&mut parent_file, "child"),
+        };
+        let _child = match (res, err) {
+            (Ok(child), None) => child,
+            (Ok(_), Some(e)) => panic!("unexpected success {:?}", e),
+            (Err(e), None) => panic!("unexpected error {:?}", e),
+            (Err(e), Some(expected_e)) => {
+                assert_eq!(e.kind(), expected_e.kind(), "{:?} != {:?}", e, expected_e);
+                return Ok(());
+            }
+        };
         let expected = renamed_parent.join("child");
         let metadata = expected.symlink_metadata()?;
-        assert!(metadata.is_dir());
+        match test.op {
+            Op::MkDir => assert!(metadata.is_dir()),
+            Op::OpenDir => (),
+            Op::OpenFile => {
+                assert!(metadata.is_file());
+                assert_eq!(metadata.len(), 0);
+            }
+        }
+        Ok(())
+    }
+
+    // basic property based framework. Performs a specific combination of
+    // options with a file-or-dir opening call, and verifies the resulting
+    // object can be used as expected. Note that this cannot be used to create
+    // actual races - but the library depends on the OS behaviour for race
+    // safety: what we are checking for here is that we're passing the right
+    // semantics down for when races do occur (e.g. O_EXCL is supplied when
+    // requested...)
+    fn check_behaviour(test: Test) -> Result<()> {
+        if test.create {
+            // run two tests: one that creates the path, and once that opens
+            // the existing path
+            _check_behaviour(test.clone(), true, None)?;
+            _check_behaviour(test.clone(), false, None)
+        } else {
+            // without create, openat is only useful on existing files.
+            if test.op != Op::MkDir {
+                return Ok(());
+            }
+            // choose one of two tests: one that creates the path where it didn't exist
+            // and one that precreates the file and expects an error
+            if test.err.is_none() {
+                _check_behaviour(test.clone(), false, None)
+            } else {
+                _check_behaviour(test.clone(), true, test.err)
+            }
+        }
+    }
+
+    #[test]
+    fn all_mkdir() -> Result<()> {
+        let err = Error::from(ErrorKind::AlreadyExists);
+        for err_ref in vec![None, Some(&err)].into_iter() {
+            for create in vec![false, true] {
+                for read in vec![false, true] {
+                    check_behaviour(
+                        Test::default()
+                            .err(err_ref)
+                            .create(create)
+                            .read(read)
+                            .op(Op::MkDir),
+                    )?;
+                }
+            }
+        }
         Ok(())
     }
 
     #[test]
-    fn mkdirat_permit_existing() -> Result<()> {
-        let (_tmp, mut parent_file, renamed_parent) = setup()?;
-        OpenOptions::default().mkdir_at(&mut parent_file, "child")?;
-        let _child: File = OpenOptions::default()
-            .create(true)
-            .mkdir_at(&mut parent_file, "child")?;
-        let expected = renamed_parent.join("child");
-        let metadata = expected.symlink_metadata()?;
-        assert!(metadata.is_dir());
-        Ok(())
-    }
-
-    #[test]
-    fn mkdirat_error_existing() -> Result<()> {
-        let (_tmp, mut parent_file, _) = setup()?;
-        OpenOptions::default().mkdir_at(&mut parent_file, "child")?;
-        OpenOptions::default()
-            .mkdir_at(&mut parent_file, "child")
-            .unwrap_err();
-        Ok(())
-    }
-
-    #[test]
-    fn openat_create_new() -> Result<()> {
-        let (_tmp, mut parent_file, renamed_parent) = setup()?;
-        let _child: File = OpenOptions::default()
-            .create(true)
-            .open_at(&mut parent_file, "child")?;
-        let expected = renamed_parent.join("child");
-        let metadata = expected.symlink_metadata()?;
-        assert!(metadata.is_file());
-        assert_eq!(metadata.len(), 0);
+    fn all_open_file() -> Result<()> {
+        let err = Error::from(ErrorKind::AlreadyExists);
+        for err_ref in vec![None, Some(&err)].into_iter() {
+            for create in vec![false, true] {
+                for read in vec![false, true] {
+                    // Filter for open: without one of read/write/append all
+                    // calls will fail
+                    if !read {
+                        continue;
+                    }
+                    check_behaviour(
+                        Test::default()
+                            .err(err_ref)
+                            .create(create)
+                            .read(read)
+                            .op(Op::OpenFile),
+                    )?;
+                }
+            }
+        }
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub struct OpenOptions {
 /// Controls the way writes to an opened file are performed. Write modes do not
 /// affect how the file is opened - creating the file or truncating it require
 /// separate options.
-#[derive(Clone, Copy, Default, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Default, Debug, Eq, PartialEq, PartialOrd)]
 pub enum OpenOptionsWriteMode {
     /// No writing permitted. Allows opening files where the process lacks write permissions, and attempts to write will fail.
     #[default]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -128,7 +128,7 @@ impl OpenOptionsImpl {
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 // IFF exclusive wasn't requested (currently the default), then
                 // proceed to open-as-dir and return existing dir.
-                if self.create {
+                if self.create && !self.create_new {
                     Ok(())
                 } else {
                     Err(e)

--- a/src/win.rs
+++ b/src/win.rs
@@ -234,22 +234,20 @@ impl OpenOptionsImpl {
 
     fn get_file_disposition(&self, call_defaults_create: bool) -> Result<FileDisposition> {
         if self.create_new {
-            return Ok(FileDisposition(FILE_CREATE));
+            Ok(FileDisposition(FILE_CREATE))
         } else if self.truncate {
-            return Ok(FileDisposition(FILE_OVERWRITE_IF));
+            Ok(FileDisposition(FILE_OVERWRITE_IF))
         } else if self.create {
-            return Ok(FileDisposition(FILE_OPEN_IF));
+            Ok(FileDisposition(FILE_OPEN_IF))
+        } else if call_defaults_create {
+            // mkdir should still work without create / truncate called -
+            // its poor ergonomics otherwise.
+            Ok(FileDisposition(FILE_CREATE))
         } else {
-            if call_defaults_create {
-                // mkdir should still work without create / truncate called -
-                // its poor ergonomics otherwise.
-                return Ok(FileDisposition(FILE_CREATE));
-            }
-            return Err(std::io::Error::from_raw_os_error(
+            Err(std::io::Error::from_raw_os_error(
                 ERROR_INVALID_PARAMETER as i32,
-            ));
+            ))
         }
-        // let file_disposition = FileDisposition(FILE_CREATE);
     }
 
     fn get_access_mode(&self) -> Result<DesiredAccess> {

--- a/src/win.rs
+++ b/src/win.rs
@@ -43,6 +43,7 @@ pub mod exports {
 #[derive(Default)]
 pub(crate) struct OpenOptionsImpl {
     create: bool,
+    read: bool,
     // LARGE_INTEGER defined as signed 64-bit
     // https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-large_integer-r1
     allocation_size: i64,
@@ -73,6 +74,10 @@ struct FileDisposition(u32);
 struct CreateOptions(u32);
 
 impl OpenOptionsImpl {
+    pub fn read(&mut self, read: bool) {
+        self.read = read;
+    }
+
     pub fn create(&mut self, create: bool) {
         self.create = create;
     }
@@ -222,7 +227,7 @@ impl OpenOptionsImpl {
         const ERROR_INVALID_PARAMETER: i32 = 87;
 
         // match (self.read, self.write, self.append, self.access_mode) {
-        Ok(DesiredAccess(match (true, false, false, None) {
+        Ok(DesiredAccess(match (self.read, false, false, None) {
             (.., Some(mode)) => mode,
             (true, false, false, None) => GENERIC_READ,
             (false, true, false, None) => GENERIC_WRITE,
@@ -278,6 +283,7 @@ pub trait OpenOptionsExt {
 
     let mut options = OpenOptions::default();
     options.allocation_size(12345);
+    options.read(true);
     let dir_file = options.mkdir_at(&mut parent_dir, "foo");
     ```
     */
@@ -306,6 +312,7 @@ pub trait OpenOptionsExt {
     let mut parent_dir = options.open(".").unwrap();
 
     let mut options = OpenOptions::default();
+    options.read(true);
     options.file_attributes(winapi::um::winnt::FILE_ATTRIBUTE_TEMPORARY);
     let dir_file = options.mkdir_at(&mut parent_dir, "foo");
     ```
@@ -332,6 +339,7 @@ pub trait OpenOptionsExt {
     let mut parent_dir = options.open(".").unwrap();
 
     let mut options = OpenOptions::default();
+    options.read(true);
     options.object_attributes(winapi::shared::ntdef::OBJ_CASE_INSENSITIVE);
     let dir_file = options.mkdir_at(&mut parent_dir, "foo");
     ```
@@ -372,6 +380,7 @@ pub trait OpenOptionsExt {
     let mut parent_dir = options.open(".").unwrap();
 
     let mut options = OpenOptions::default();
+    options.read(true);
     options.security_qos_impersonation(winapi::um::winnt::SecurityIdentification);
     let dir_file = options.mkdir_at(&mut parent_dir, "foo");
     ```
@@ -399,6 +408,7 @@ pub trait OpenOptionsExt {
     let mut parent_dir = options.open(".").unwrap();
 
     let mut options = OpenOptions::default();
+    options.read(true);
     options.security_qos_context_tracking(winapi::um::winnt::SECURITY_DYNAMIC_TRACKING);
     let dir_file = options.mkdir_at(&mut parent_dir, "foo");
     ```
@@ -426,6 +436,7 @@ pub trait OpenOptionsExt {
     let mut parent_dir = options.open(".").unwrap();
 
     let mut options = OpenOptions::default();
+    options.read(true);
     options.security_qos_effective_only(true);
     let dir_file = options.mkdir_at(&mut parent_dir, "foo");
     ```

--- a/src/win.rs
+++ b/src/win.rs
@@ -46,6 +46,7 @@ pub mod exports {
 #[derive(Default)]
 pub(crate) struct OpenOptionsImpl {
     create: bool,
+    create_new: bool,
     truncate: bool,
     read: bool,
     write: OpenOptionsWriteMode,
@@ -93,6 +94,10 @@ impl OpenOptionsImpl {
 
     pub fn create(&mut self, create: bool) {
         self.create = create;
+    }
+
+    pub fn create_new(&mut self, create_new: bool) {
+        self.create_new = create_new;
     }
 
     fn do_create_file(
@@ -228,7 +233,9 @@ impl OpenOptionsImpl {
     }
 
     fn get_file_disposition(&self, call_defaults_create: bool) -> Result<FileDisposition> {
-        if self.truncate {
+        if self.create_new {
+            return Ok(FileDisposition(FILE_CREATE));
+        } else if self.truncate {
             return Ok(FileDisposition(FILE_OVERWRITE_IF));
         } else if self.create {
             return Ok(FileDisposition(FILE_OPEN_IF));


### PR DESCRIPTION
This rounds out open_at, leaving currently 'extensions' like no-follow and symlinks to be implemented.