### PR TITLE
Rewrite cfg_if into simple cfg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.0.1-alpha1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cfg-if = "1.0.0"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,17 +19,17 @@ use std::{
     path::Path,
 };
 
-cfg_if::cfg_if! {
-    if #[cfg(windows)] {
-        mod win;
+#[cfg(windows)]
+mod win;
 
-        use win::OpenOptionsImpl;
-    } else {
-        mod unix;
+#[cfg(windows)]
+use win::OpenOptionsImpl;
 
-        use unix::OpenOptionsImpl;
-    }
-}
+#[cfg(unix)]
+mod unix;
+
+#[cfg(unix)]
+use unix::OpenOptionsImpl;
 
 /// Similar to [`std::fs::OpenOptions`], this struct is used to parameterise the
 /// various at functions, which are then called on the struct itself. Typical
@@ -199,13 +199,10 @@ impl OpenOptions {
 }
 
 pub mod os {
-    cfg_if::cfg_if! {
-        if #[cfg(windows)] {
-            pub use crate::win::exports as windows;
-        } else {
-            pub use crate::unix::exports as unix;
-        }
-    }
+    #[cfg(unix)]
+    pub use crate::unix::exports as unix;
+    #[cfg(windows)]
+    pub use crate::win::exports as windows;
 }
 
 #[cfg(test)]

--- a/src/testsupport.rs
+++ b/src/testsupport.rs
@@ -4,28 +4,24 @@ use std::{
     path::Path,
 };
 
-cfg_if::cfg_if! {
-    if #[cfg(windows)] {
-        pub fn open_dir(p:&Path) -> Result<File> {
-            use std::os::windows::fs::OpenOptionsExt;
+#[cfg(windows)]
+pub fn open_dir(p: &Path) -> Result<File> {
+    use std::os::windows::fs::OpenOptionsExt;
 
-            use winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
+    use winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
 
-            let mut options = OpenOptions::new();
-            options.read(true);
-            options.custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
-            options.open(p)
-        }
-    } else {
-        pub fn open_dir(p:&Path) -> Result<File> {
-            use std::os::unix::fs::OpenOptionsExt;
+    let mut options = OpenOptions::new();
+    options.read(true);
+    options.custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
+    options.open(p)
+}
 
-            use libc;
+#[cfg(unix)]
+pub fn open_dir(p: &Path) -> Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
 
-            let mut options = OpenOptions::new();
-            options.read(true);
-            options.custom_flags(libc::O_NOFOLLOW);
-            options.open(p)
-        }
-    }
+    let mut options = OpenOptions::new();
+    options.read(true);
+    options.custom_flags(libc::O_NOFOLLOW);
+    options.open(p)
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -8,13 +8,10 @@ use std::{
 
 // This will probably take a few iterations to get right. The idea: always use
 // an openat64, and import the right variant for the platform. See File::open_c in [`std::sys::unix::fs`].
-cfg_if::cfg_if! {
-    if #[cfg(target_os="macos")] {
-        use libc::openat as openat64;
-    } else {
-        use libc::openat64;
-    }
-}
+#[cfg(target_os = "macos")]
+use libc::openat as openat64;
+#[cfg(not(target_os = "macos"))]
+use libc::openat64;
 
 use cvt::cvt_r;
 use libc::{c_int, mkdirat, mode_t};


### PR DESCRIPTION
Removes a dependency and makes the code more
transparent to rust-analyzer and cargo-mutants.

For example an unused-import warning shows up with this removed.
