### PR TITLE
Create a helper `open_dir_at`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "857cf27edcb26c2a36d84b2954019573d335bb289876113aceacacdca47a4fd4"
+dependencies = [
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "fs_at"
 version = "0.0.5"
 dependencies = [
@@ -113,6 +124,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cvt",
  "env_logger",
+ "fs-set-times",
  "libc",
  "log",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ log = { version = "0.4.17", optional = true }
 [dev-dependencies]
 tempfile = "3.3.0"
 test-log = "0.2.11"
+fs-set-times = "0.18.1"
 
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2.137"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1140,10 +1140,9 @@ mod tests {
                 .read(true)
                 .open_dir_at(&parent_dir, "dir")?;
             OpenOptions::default().read(true).open_at(&dir, "file")?;
-            let children = super::read_dir(&mut dir)?
-                .map(|dir_entry| dir_entry.unwrap().name().to_owned())
-                .collect::<Vec<_>>();
-            assert_eq!(3, children.len());
+            let children =
+                super::read_dir(&mut dir)?.map(|dir_entry| dir_entry.unwrap().name().to_owned());
+            assert_eq!(3, children.count());
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1119,7 +1119,11 @@ mod tests {
             let dir = OpenOptions::default()
                 .write(OpenOptionsWriteMode::Write)
                 .open_dir_at(&parent_dir, "dir")?;
-                fs_set_times::SetTimes::set_times(&dir, None, Some(fs_set_times::SystemTimeSpec::Absolute(reference_time)))?;
+            fs_set_times::SetTimes::set_times(
+                &dir,
+                None,
+                Some(fs_set_times::SystemTimeSpec::Absolute(reference_time)),
+            )?;
         }
 
         // case 3: read - can we read the dir's date
@@ -1135,11 +1139,11 @@ mod tests {
             let mut dir = OpenOptions::default()
                 .read(true)
                 .open_dir_at(&parent_dir, "dir")?;
-             OpenOptions::default().read(true).open_at(&dir, "file")?;
+            OpenOptions::default().read(true).open_at(&dir, "file")?;
             let children = super::read_dir(&mut dir)?
                 .map(|dir_entry| dir_entry.unwrap().name().to_owned())
                 .collect::<Vec<_>>();
-        assert_eq!(3, children.len());
+            assert_eq!(3, children.len());
         }
 
         Ok(())

--- a/src/win.rs
+++ b/src/win.rs
@@ -451,18 +451,6 @@ impl OpenOptionsImpl {
             create_options,
             open_symlink,
         )
-        .map_err(|e| {
-            // if e.raw_os_error() == Some(ERROR_DIRECTORY as i32) {
-            //     // NotADirectory happens when opening with FILE_OVERWRITE_IF
-            //     // (e.g. truncate) a Symlink with link-type Dir and follow enabled. But
-            //     // AlreadyExists is a better error consistent with Unix : the
-            //     // NotADirectory error is leakage from the implementation of
-            //     // symlinks on Windows. Here we need to retry
-            //     io::Error::new(ErrorKind::AlreadyExists, e)
-            // } else {
-            e
-            // }
-        })
     }
 
     pub fn symlink_at(

--- a/src/win.rs
+++ b/src/win.rs
@@ -50,6 +50,7 @@ use winapi::{
 };
 
 use sugar::{NTStatusError, OSUnicodeString};
+use windows_sys::Win32::Storage::FileSystem::FILE_READ_ATTRIBUTES;
 
 use crate::{LinkEntryType, OpenOptions, OpenOptionsWriteMode};
 
@@ -363,7 +364,7 @@ impl OpenOptionsImpl {
         // Rust itself uses - this lets the OS position tracker work. It also
         // requires SYNCHRONIZE on the access mode. We should permit users to
         // expect particular types, but until we make that explicit, we need to
-        // open any kind of file when requested # FILE_NON_DIRECTORY_FILE |
+        // open any kind of file when requested
         let create_options = CreateOptions(
             FILE_SYNCHRONOUS_IO_NONALERT
                 | if let Some(CreateOptions(custom_options)) = self.create_options {
@@ -410,6 +411,57 @@ impl OpenOptionsImpl {
             } else {
                 e
             }
+        })
+    }
+
+    pub fn open_dir_at(&self, f: &File, path: &Path) -> Result<File> {
+        let desired_access = self.get_open_dir_at_access_mode()?;
+        let create_disposition = self.get_file_disposition(false)?;
+        // TODO: create options needs to be controlled through OpenOptions too.
+        // FILE_SYNCHRONOUS_IO_NONALERT is set by CreateFile with the options
+        // Rust itself uses - this lets the OS position tracker work. It also
+        // requires SYNCHRONIZE on the access mode. We should permit users to
+        // expect particular types, but until we make that explicit, we need to
+        // open any kind of file when requested # FILE_NON_DIRECTORY_FILE |
+        let create_options = CreateOptions(
+            FILE_SYNCHRONOUS_IO_NONALERT
+                | if let Some(CreateOptions(custom_options)) = self.create_options {
+                    custom_options
+                } else {
+                    FILE_OPEN_REPARSE_POINT
+                },
+        );
+        #[cfg(feature = "log")]
+        log::trace!(
+            "open_dir_at: {}, access: {:#0x?} create_options: {:#0x?}",
+            path.display(),
+            desired_access.0,
+            create_options.0
+        );
+        let open_symlink = {
+            // Be compatible with Unix code - O_NOFOLLOW without O_PATH generates ELOOP.
+            OpenSymLink::RaiseError(make_loop_error)
+        };
+
+        self.do_create_file(
+            f,
+            path,
+            desired_access,
+            create_disposition,
+            create_options,
+            open_symlink,
+        )
+        .map_err(|e| {
+            // if e.raw_os_error() == Some(ERROR_DIRECTORY as i32) {
+            //     // NotADirectory happens when opening with FILE_OVERWRITE_IF
+            //     // (e.g. truncate) a Symlink with link-type Dir and follow enabled. But
+            //     // AlreadyExists is a better error consistent with Unix : the
+            //     // NotADirectory error is leakage from the implementation of
+            //     // symlinks on Windows. Here we need to retry
+            //     io::Error::new(ErrorKind::AlreadyExists, e)
+            // } else {
+            e
+            // }
         })
     }
 
@@ -666,6 +718,34 @@ impl OpenOptionsImpl {
             (.., Some(mode)) => mode,
             (OpenOptionsWriteMode::Write, None) => GENERIC_WRITE,
             (OpenOptionsWriteMode::Append, None) => FILE_GENERIC_WRITE & !FILE_WRITE_DATA,
+            _ => 0,
+        };
+
+        if desired_access == SYNCHRONIZE {
+            // neither read nor write modes selected
+            return Err(io::Error::from_raw_os_error(ERROR_INVALID_PARAMETER as i32));
+        }
+        Ok(DesiredAccess(desired_access))
+    }
+
+    fn get_open_dir_at_access_mode(&self) -> Result<DesiredAccess> {
+        // FILE_SYNCHRONOUS_IO_NONALERT is set by CreateFile with the options
+        // Rust itself uses - this lets the OS position tracker work. It also
+        // requires SYNCHRONIZE on the access mode.
+        let mut desired_access = SYNCHRONIZE;
+        if let Some(DesiredAccess(custom_access)) = self.desired_access {
+            return Ok(DesiredAccess(custom_access | desired_access));
+        }
+
+        if self.read {
+            desired_access |= FILE_READ_ATTRIBUTES | FILE_LIST_DIRECTORY | FILE_TRAVERSE;
+        }
+
+        // rust has match (self.read, self.write, self.append, self.access_mode) {
+        desired_access |= match (self.write, None) {
+            (.., Some(mode)) => mode,
+            (OpenOptionsWriteMode::Write, None) => FILE_WRITE_ATTRIBUTES | DELETE,
+            (OpenOptionsWriteMode::Append, None) => FILE_WRITE_ATTRIBUTES | DELETE,
             _ => 0,
         };
 


### PR DESCRIPTION
This abstracts over the cross-platform variation in safely opening a
directory.