### PR TITLE
finish windows_sys port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,13 +183,11 @@ dependencies = [
  "libc",
  "log",
  "nix",
- "ntapi",
  "once_cell",
  "rayon",
  "smart-default",
  "tempfile",
  "test-log",
- "winapi",
  "windows-sys",
 ]
 
@@ -291,15 +289,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "static_assertions",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
-dependencies = [
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ log = ["dep:log"]
 [dependencies]
 cfg-if = "1.0.0"
 cvt = "0.1.1"
-env_logger = "0.10.0"
 log = { version = "0.4.17", optional = true }
 
 [dev-dependencies]
@@ -28,6 +27,7 @@ tempfile = "3.3.0"
 test-log = "0.2.11"
 fs-set-times = "0.18.1"
 rayon = "1.6.1"
+env_logger = "0.10.0"
 
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2.139"
@@ -38,25 +38,8 @@ nix = { version = "0.26.2", default-features = false, features = ["dir"] }
 
 [target.'cfg(windows)'.dependencies]
 aligned = "0.4.1"
-ntapi = "0.4.0"
 once_cell = { optional = true, version = "1.17.0" }
-winapi = { version = "0.3", features = [
-    "ntdef",
-    "minwindef",
-    "ioapiset",
-    "winerror",
-    "libloaderapi",
-    "winbase",
-    "winuser",
-] }
 smart-default="0.6.0"
-
-# [target.'cfg(windows)'.dependencies.windows-sys]
-# features = [
-#     "Win32_System_IO",
-#     "Win32_System_Threading",
-# ]
-# version = "0.45.0"
 
 
 [target.'cfg(windows)'.dependencies.windows-sys]
@@ -68,6 +51,7 @@ features = [
     "Win32_System_WindowsProgramming",
     "Win32_Security",
     "Win32_System_Kernel",
+    "Win32_System_IO",
     "Win32_System_Ioctl"
 ]
 version = "0.45.0"

--- a/src/win.rs
+++ b/src/win.rs
@@ -13,40 +13,105 @@ use std::{
 };
 
 use aligned::{Aligned, A8};
-use ntapi::ntioapi::{
-    REPARSE_DATA_BUFFER_u_SymbolicLinkReparseBuffer, FILE_CREATE, FILE_CREATED,
-    FILE_DIRECTORY_FILE, FILE_DOES_NOT_EXIST, FILE_EXISTS, FILE_OPEN, FILE_OPENED, FILE_OPEN_IF,
-    FILE_OPEN_REPARSE_POINT, FILE_OVERWRITE_IF, FILE_OVERWRITTEN, FILE_SUPERSEDED,
-    FILE_SYNCHRONOUS_IO_NONALERT, REPARSE_DATA_BUFFER, SYMLINK_FLAG_RELATIVE,
-};
-use winapi::um::winnt::SECURITY_CONTEXT_TRACKING_MODE;
 
 use sugar::{NTStatusError, OSUnicodeString};
 use windows_sys::Win32::{
-    Foundation::{ERROR_CANT_RESOLVE_FILENAME, HANDLE, TRUE, ERROR_DIRECTORY, ERROR_NOT_A_REPARSE_POINT, ERROR_INVALID_PARAMETER, ERROR_NO_MORE_FILES},
+    Foundation::{
+        ERROR_CANT_RESOLVE_FILENAME, ERROR_DIRECTORY, ERROR_INVALID_PARAMETER,
+        ERROR_NOT_A_REPARSE_POINT, ERROR_NO_MORE_FILES, HANDLE, TRUE,
+    },
+    Security::{SECURITY_DESCRIPTOR, SECURITY_QUALITY_OF_SERVICE},
     Storage::FileSystem::{
         FileDispositionInfo, FileIdBothDirectoryInfo, FileIdBothDirectoryRestartInfo,
         GetFileInformationByHandleEx, NtCreateFile, SetFileInformationByHandle, DELETE,
-        FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_WRITE, FILE_INFO_BY_HANDLE_CLASS, FILE_LIST_DIRECTORY,
-        FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_TRAVERSE,
-        FILE_WRITE_ATTRIBUTES, FILE_WRITE_DATA, FILE_DISPOSITION_INFO, FILE_ID_BOTH_DIR_INFO, SYNCHRONIZE, MAXIMUM_REPARSE_DATA_BUFFER_SIZE,
+        FILE_ATTRIBUTE_NORMAL, FILE_CREATE, FILE_DISPOSITION_INFO, FILE_GENERIC_WRITE,
+        FILE_ID_BOTH_DIR_INFO, FILE_INFO_BY_HANDLE_CLASS, FILE_LIST_DIRECTORY, FILE_OPEN,
+        FILE_OPEN_IF, FILE_OVERWRITE_IF, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE, FILE_TRAVERSE, FILE_WRITE_ATTRIBUTES, FILE_WRITE_DATA,
+        MAXIMUM_REPARSE_DATA_BUFFER_SIZE, SYNCHRONIZE,
     },
     System::{
-        SystemServices::{GENERIC_READ, GENERIC_WRITE, IO_REPARSE_TAG_SYMLINK, IO_REPARSE_TAG_MOUNT_POINT},
-        WindowsProgramming::OBJECT_ATTRIBUTES,
-        IO::DeviceIoControl, Kernel::OBJ_CASE_INSENSITIVE, Ioctl::{FSCTL_SET_REPARSE_POINT, FSCTL_GET_REPARSE_POINT},
-    }, Security::{SECURITY_DESCRIPTOR, SECURITY_QUALITY_OF_SERVICE},
+        Ioctl::{FSCTL_GET_REPARSE_POINT, FSCTL_SET_REPARSE_POINT},
+        Kernel::OBJ_CASE_INSENSITIVE,
+        SystemServices::{
+            GENERIC_READ, GENERIC_WRITE, IO_REPARSE_TAG_MOUNT_POINT, IO_REPARSE_TAG_SYMLINK,
+        },
+        WindowsProgramming::{
+            FILE_CREATED, FILE_DIRECTORY_FILE, FILE_DOES_NOT_EXIST, FILE_EXISTS, FILE_OPENED,
+            FILE_OPEN_REPARSE_POINT, FILE_OVERWRITTEN, FILE_SUPERSEDED,
+            FILE_SYNCHRONOUS_IO_NONALERT, OBJECT_ATTRIBUTES,
+        },
+        IO::DeviceIoControl,
+    },
 };
 
 use crate::{LinkEntryType, OpenOptions, OpenOptionsWriteMode};
 
+use exports::SECURITY_CONTEXT_TRACKING_MODE;
+
+use self::reparse_definitions::{
+    REPARSE_DATA_BUFFER_u_SymbolicLinkReparseBuffer, REPARSE_DATA_BUFFER,
+};
+
 pub mod exports {
     pub use super::OpenOptionsExt;
-    #[doc(no_inline)]
-    pub use winapi::um::winnt::SECURITY_CONTEXT_TRACKING_MODE;
+    // SECURITY_CONTEXT_TRACKING_MODE is not available in windows_sys yet, but it's a pretty simple definition
+    // so in order to maintain API compatibility we'll replicate it here.
+    #[allow(non_camel_case_types)]
+    pub type SECURITY_CONTEXT_TRACKING_MODE = u8;
 
     #[doc(no_inline)]
     pub use windows_sys::Win32::Security::SECURITY_DESCRIPTOR;
+}
+
+/// Strictly speaking this should be provided by something like windows_sys, however the definition isn't there,
+/// so we'll replicate it from the headers. These structures impact safety sensitive code and should only be changed
+/// in order to more accurately reflect the definition in Ntifs.h
+#[allow(non_snake_case)]
+mod reparse_definitions {
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct REPARSE_DATA_BUFFER {
+        pub ReparseTag: u32,
+        pub ReparseDataLength: u16,
+        pub Reserved: u16,
+        pub u: REPARSE_DATA_BUFFER_u,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub union REPARSE_DATA_BUFFER_u {
+        pub SymbolicLinkReparseBuffer: REPARSE_DATA_BUFFER_u_SymbolicLinkReparseBuffer,
+        pub MountPointReparseBuffer: REPARSE_DATA_BUFFER_u_MountPointReparseBuffer,
+        pub GenericReparseBuffer: REPARSE_DATA_BUFFER_u_GenericReparseBuffer,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct REPARSE_DATA_BUFFER_u_SymbolicLinkReparseBuffer {
+        pub SubstituteNameOffset: u16,
+        pub SubstituteNameLength: u16,
+        pub PrintNameOffset: u16,
+        pub PrintNameLength: u16,
+        pub Flags: u32,
+        pub PathBuffer: [u16; 1],
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct REPARSE_DATA_BUFFER_u_MountPointReparseBuffer {
+        pub SubstituteNameOffset: u16,
+        pub SubstituteNameLength: u16,
+        pub PrintNameOffset: u16,
+        pub PrintNameLength: u16,
+        pub PathBuffer: [u16; 1],
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct REPARSE_DATA_BUFFER_u_GenericReparseBuffer {
+        pub DataBuffer: [u16; 1],
+    }
 }
 
 #[derive(Clone, Default)]
@@ -219,7 +284,7 @@ impl OpenOptionsImpl {
         // https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-security_quality_of_service
         let mut security_qos = self.security_qos;
         object_attributes.SecurityQualityOfService = match security_qos {
-            Some(ref mut val) => val as * mut SECURITY_QUALITY_OF_SERVICE as *mut c_void,
+            Some(ref mut val) => val as *mut SECURITY_QUALITY_OF_SERVICE as *mut c_void,
             None => ptr::null_mut(),
         };
         let mut status_block = MaybeUninit::uninit();
@@ -521,6 +586,8 @@ impl OpenOptionsImpl {
 
         reparse_data.ReparseDataLength = to_u16(reparse_data_length)?;
         if !absolute {
+            // Usually this is defined in a C header. There is no Rust equivalent of this in windows_sys yet, so we redefine it here.
+            const SYMLINK_FLAG_RELATIVE: u32 = 1;
             reparse_data.u.SymbolicLinkReparseBuffer.Flags = SYMLINK_FLAG_RELATIVE;
         }
         reparse_data

--- a/src/win/sugar.rs
+++ b/src/win/sugar.rs
@@ -8,9 +8,14 @@ pub struct NTStatusError {
     pub status: NTSTATUS,
 }
 
+/// Mimics the behavior of the NT_SUCCESS macro from Microsoft C headers
+fn nt_success(status: NTSTATUS) -> bool {
+    status >= 0
+}
+
 impl NTStatusError {
     pub fn from(status: NTSTATUS) -> std::result::Result<(), NTStatusError> {
-        if status >= 0 {
+        if nt_success(status) {
             Ok(())
         } else {
             Err(NTStatusError { status })
@@ -48,16 +53,10 @@ impl TryFrom<Vec<u16>> for OSUnicodeString {
         content.push(0);
         let mut inner = MaybeUninit::uninit();
         unsafe { NTStatusError::from(init_unicode_string(inner.as_mut_ptr(), &mut content)) }?;
-        // The manual copying of fields is because RtlInitUnicodeStringEx is
-        // working on the winapi type definition.
         let winapi_string = unsafe { inner.assume_init() };
         Ok(OSUnicodeString {
             _content: content,
-            inner: UNICODE_STRING {
-                Length: winapi_string.Length,
-                MaximumLength: winapi_string.MaximumLength,
-                Buffer: winapi_string.Buffer,
-            },
+            inner: winapi_string,
         })
     }
 }


### PR DESCRIPTION
Removes reliance on `winapi`. Note the tests still use `winapi` because `env_logger` uses `termcolor` which uses `winapi`. However `env_logger` has been moved into `[dev-dependencies]` because it doesn't need to be a dependency. 