### PR TITLE
Update unix.rs to point at correct use libc::openat for `netbsd` and `illumos`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "fs_at"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "aligned",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "fs_at"
 readme = "README.md"
 repository = "https://github.com/rbtcollins/fs_at.git"
 rust-version = "1.62.0"
-version = "0.1.2"
+version = "0.1.3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,9 +501,9 @@ mod tests {
         time::{Duration, SystemTime},
     };
 
+    use rayon::prelude::*;
     use tempfile::TempDir;
     use test_log::test;
-    use rayon::prelude::*;
 
     use crate::{
         read_dir, testsupport::open_dir, DirEntry, LinkEntryType, OpenOptions, OpenOptionsWriteMode,
@@ -1036,14 +1036,16 @@ mod tests {
     fn readdir_sync_send() -> Result<()> {
         let (_tmp, mut parent_dir, _pathname) = setup()?;
         let dirstream = read_dir(&mut parent_dir)?;
-        dirstream.par_bridge().try_for_each(|dir_entry| -> Result<()> {
-            dir_entry?;
-            Ok(())
-        })?;
+        dirstream
+            .par_bridge()
+            .try_for_each(|dir_entry| -> Result<()> {
+                dir_entry?;
+                Ok(())
+            })?;
         Ok(())
     }
 
-     #[test]
+    #[test]
     fn readdir() -> Result<()> {
         let (_tmp, mut parent_dir, _pathname) = setup()?;
         assert_eq!(

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -11,7 +11,7 @@ use std::{
 // This will probably take a few iterations to get right. The idea: always use
 // an openat64, and import the right variant for the platform. See File::open_c in [`std::sys::unix::fs`].
 cfg_if::cfg_if! {
-    if #[cfg(any(target_os="macos", target_os="freebsd", target_os="ios"))] {
+    if #[cfg(any(target_os="macos", target_os="freebsd", target_os="ios", target_os="netbsd", target_os="illumos"))] {
         use libc::openat as openat64;
     } else {
         use libc::openat64;
@@ -269,7 +269,7 @@ pub(crate) struct ReadDirImpl<'a> {
 // used (e.g. cloning the fd before constructing a ReadDirImpl). Its possible
 // that on some platforms DIR is radically different, so we depend on Box<> to
 // figure out Send-ability of DIR.
-unsafe impl<'a> Send for ReadDirImpl<'a> where Box<libc::DIR> : Send {}
+unsafe impl<'a> Send for ReadDirImpl<'a> where Box<libc::DIR>: Send {}
 
 // Safety: As above, DIR is aligned etc;  further all mutation uses mutable
 // borrows. There is no way to go from ReadDirImpl to &Dir, and synchronisation
@@ -286,8 +286,7 @@ unsafe impl<'a> Send for ReadDirImpl<'a> where Box<libc::DIR> : Send {}
 // constraint. POSIX does not require memory barriers, merely that no thread is
 // using the data returned by a different call. next() takes care to copy out
 // data to an OsString before returning, meeting that requirement.
-unsafe impl<'a> Sync for ReadDirImpl<'a> where Box<libc::DIR> : Sync {}
-
+unsafe impl<'a> Sync for ReadDirImpl<'a> where Box<libc::DIR>: Sync {}
 
 impl<'a> ReadDirImpl<'a> {
     pub fn new(dir_file: &'a mut File) -> Result<Self> {


### PR DESCRIPTION
- close https://github.com/rbtcollins/fs_at/issues/58
- update version in Cargo.lock.
- `cargo fmt --all`
