### PR TITLE
Vendor cvt as a module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,12 +49,6 @@ checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -65,7 +59,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -75,7 +69,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -87,7 +81,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "memoffset",
  "scopeguard",
@@ -99,16 +93,7 @@ version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "cvt"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac344c7efccb80cd25bc61b2170aec26f2f693fd40e765a539a1243db48c71"
-dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -176,8 +161,7 @@ name = "fs_at"
 version = "0.1.3"
 dependencies = [
  "aligned",
- "cfg-if 1.0.0",
- "cvt",
+ "cfg-if",
  "env_logger",
  "fs-set-times",
  "libc",
@@ -218,7 +202,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -261,7 +245,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -286,7 +270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "static_assertions",
 ]
@@ -442,7 +426,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "libc",
  "redox_syscall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ log = ["dep:log"]
 
 [dependencies]
 cfg-if = "1.0.0"
-cvt = "0.1.1"
 log = { version = "0.4.17", optional = true }
 
 [dev-dependencies]

--- a/src/cvt.rs
+++ b/src/cvt.rs
@@ -1,0 +1,24 @@
+//! This package exposes the `cvt` function used extensively by `libstd` to
+//! convert platform-specific syscall error codes to `std::io::Result`.
+//!
+//! Usually syscalls use return values for errors, the conventions differ. For instance,
+//! on Unix `0` usually means success on Unix but failure on Windows.
+//! While those conventions are not always followed, they usually are and
+//! `cvt` is there to reduce the mental bookkeeping and make it easier to handle syscall errors.
+//!
+//! The code was mostly copied over from Rust libstd, because the function is not public.
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "vxworks")] {
+        mod vxworks;
+        pub use self::vxworks::{cvt, cvt_r};
+    } else if #[cfg(unix)] {
+        mod unix;
+        pub use self::unix::{cvt, cvt_r};
+    } else if #[cfg(windows)] {
+        mod windows;
+        pub use self::windows::cvt;
+    } else {
+        compile_error!("cvt doesn't compile for this platform yet");
+    }
+}

--- a/src/cvt/unix.rs
+++ b/src/cvt/unix.rs
@@ -1,0 +1,36 @@
+use std::io::ErrorKind;
+
+#[doc(hidden)]
+pub trait IsMinusOne {
+    fn is_minus_one(&self) -> bool;
+}
+
+macro_rules! impl_is_minus_one {
+    ($($t:ident)*) => ($(impl IsMinusOne for $t {
+        fn is_minus_one(&self) -> bool {
+            *self == -1
+        }
+    })*)
+}
+
+impl_is_minus_one! { i8 i16 i32 i64 isize }
+
+pub fn cvt<T: IsMinusOne>(t: T) -> std::io::Result<T> {
+    if t.is_minus_one() {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(t)
+    }
+}
+
+pub fn cvt_r<T, F>(mut f: F) -> std::io::Result<T>
+    where T: IsMinusOne,
+          F: FnMut() -> T
+{
+    loop {
+        match cvt(f()) {
+            Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
+            other => return other,
+        }
+    }
+}

--- a/src/cvt/vxworks.rs
+++ b/src/cvt/vxworks.rs
@@ -1,0 +1,36 @@
+use std::io::ErrorKind;
+
+#[doc(hidden)]
+pub trait IsMinusOne {
+    fn is_minus_one(&self) -> bool;
+}
+
+macro_rules! impl_is_minus_one {
+    ($($t:ident)*) => ($(impl IsMinusOne for $t {
+        fn is_minus_one(&self) -> bool {
+            *self == -1
+        }
+    })*)
+}
+
+impl_is_minus_one! { i8 i16 i32 i64 isize }
+
+pub fn cvt<T: IsMinusOne>(t: T) -> std::io::Result<T> {
+    if t.is_minus_one() {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(t)
+    }
+}
+
+pub fn cvt_r<T, F>(mut f: F) -> std::io::Result<T>
+    where T: IsMinusOne,
+          F: FnMut() -> T
+{
+    loop {
+        match cvt(f()) {
+            Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
+            other => return other,
+        }
+    }
+}

--- a/src/cvt/windows.rs
+++ b/src/cvt/windows.rs
@@ -1,0 +1,21 @@
+pub trait IsZero {
+    fn is_zero(&self) -> bool;
+}
+
+macro_rules! impl_is_zero {
+    ($($t:ident)*) => ($(impl IsZero for $t {
+        fn is_zero(&self) -> bool {
+            *self == 0
+        }
+    })*)
+}
+
+impl_is_zero! { i8 i16 i32 i64 isize u8 u16 u32 u64 usize }
+
+pub fn cvt<I: IsZero>(i: I) -> std::io::Result<I> {
+    if i.is_zero() {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(i)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ use std::{
     path::Path,
 };
 
+mod cvt;
+
 cfg_if::cfg_if! {
     if #[cfg(windows)] {
         mod win;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -18,7 +18,7 @@ cfg_if::cfg_if! {
     }
 }
 
-use cvt::cvt_r;
+use crate::cvt::cvt_r;
 use libc::{c_int, mkdirat, mode_t};
 
 use crate::{LinkEntryType, OpenOptions, OpenOptionsWriteMode};


### PR DESCRIPTION
This avoids another dependency and a duplication of the cfg-if dependency in tree.

`cvt` is small and self-contained. It's probably easier to just carry around that code here than to rely on the dependency updating in lock step.
(I'm working on Firefox, where we transitively depend on `fs_at`, but also try to avoid duplicated dependencies [we vendor everything])