### PR TITLE
Add open_path_at, delete_by_handle APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ cvt = "0.1.1"
 log = { version = "0.4.17", optional = true }
 
 [dev-dependencies]
-tempfile = "3.3.0"
-test-log = "0.2.11"
+env_logger = "0.10.0"
 fs-set-times = "0.19.0"
 rayon = "1.6.1"
-env_logger = "0.10.0"
+tempfile = "3.3.0"
+test-log = "0.2.11"
 
 [target.'cfg(not(windows))'.dependencies]
-libc = "0.2.139"
+libc = "0.2.140"
 # Saves nontrivial unsafe and platform specific code (Darwin vs other Unixes,
 # MAX_PATH and more : consider it weak and something we can remove if expedient
 # later.
@@ -39,7 +39,7 @@ nix = { version = "0.26.2", default-features = false, features = ["dir"] }
 [target.'cfg(windows)'.dependencies]
 aligned = "0.4.1"
 once_cell = { optional = true, version = "1.17.1" }
-smart-default="0.6.0"
+smart-default = "0.6.0"
 
 
 [target.'cfg(windows)'.dependencies.windows-sys]
@@ -52,6 +52,6 @@ features = [
     "Win32_Security",
     "Win32_System_Kernel",
     "Win32_System_IO",
-    "Win32_System_Ioctl"
+    "Win32_System_Ioctl",
 ]
 version = "0.45.0"

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -124,6 +124,13 @@ impl OpenOptionsImpl {
         self._open_at(d, path, flags)
     }
 
+    #[cfg(not(target_os = "macos"))]
+    pub fn open_path_at(&self, d: &File, path: &Path) -> Result<File> {
+        let flags =
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_PATH | libc::O_CLOEXEC | libc::O_NOCTTY;
+        self._open_at(d, path, flags)
+    }
+
     fn _open_at(&self, d: &File, path: &Path, flags: i32) -> Result<File> {
         let path = path.as_cstring()?;
         let mode = self.mode.unwrap_or(0o777);

--- a/src/win.rs
+++ b/src/win.rs
@@ -72,9 +72,11 @@ pub(crate) mod windows_sys_gap_defs {
         },
     };
 
-    // RtlInitUnicodeStringEx isn't available in windows_sys at this time (see https://github.com/microsoft/win32metadata/issues/1461)
-    // so we're going to roll our own. We'll rely on RtlInitUnicodeString to do this, and just make sure we don't pass it information that would
-    // induce an error.
+    // RtlInitUnicodeStringEx isn't available in windows_sys at this time, and
+    // won't be (see https://github.com/microsoft/win32metadata/issues/1461) so
+    // we're going to roll our own. We'll rely on RtlInitUnicodeString to do
+    // this, and just make sure we don't pass it information that would induce
+    // an error.
     pub unsafe fn init_unicode_string(
         destination_string: *mut UNICODE_STRING,
         source_string: &mut [u16],


### PR DESCRIPTION
This permits optimal delete behaviour on Windows: open a path with
DELETE | FILE_LIST_DIRECTORY, delete any children recursively, then
delete the already open file through the open handle.