### PR TITLE
Bump MSRV to 1.63

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        channel: ["1.62.1", stable, nightly]
+        channel: ["1.63", stable, nightly]
         target: [x86_64-unknown-freebsd]
         nightly: [false]
         include:
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        channel: ["1.62.1", stable, nightly]
+        channel: ["1.63", stable, nightly]
         os: [ubuntu, macos]
         nightly: [false]
         include:
@@ -139,7 +139,7 @@ jobs:
         # "gnu" on windows isn't particularly interesting/different but very slow in
         # CI. Skip unless/until we have a bug report where it matters.
         variant: [msvc]
-        channel: ["1.62.1", stable, nightly]
+        channel: ["1.63", stable, nightly]
         nightly: [false]
         exclude:
           - arch: aarch64

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.linkedProjects": [
+        ".\\Cargo.toml"
+    ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "fs_at"
 readme = "README.md"
 repository = "https://github.com/rbtcollins/fs_at.git"
-rust-version = "1.62.0"
+rust-version = "1.63.0"
 version = "0.1.8"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Truncate+nofollow also varies by platform: See OpenOptions::truncate.
 
 I'll keep this compiling against older rusts as long as it is easy, but not at
 the expense of a lot of code golf, or past CVEs in old releases of dependencies.
-Currently MSRV is 1.62. If there is a lot of interest in older versions I'm open
+Currently MSRV is 1.63. If there is a lot of interest in older versions I'm open
 to patches.
 
 ## Usage


### PR DESCRIPTION
The io-lifetimes dependency requires 1.63 as of
https://github.com/sunfishcode/io-lifetimes/pull/70/files