### PR TITLE
Fix nightly lint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,7 +118,8 @@ jobs:
       - name: test
         run: cargo test
       - name: Lint
-        run: cargo clippy --all-targets --no-deps -- -D warnings
+        # unknown-lints permits fixing lints on nightly without breaking stable
+        run: cargo clippy --all-targets --no-deps -- -D warnings -A unknown-lints
   build-windows:
     runs-on: windows-latest
     continue-on-error: ${{ matrix.channel == 'nightly' }}
@@ -205,4 +206,5 @@ jobs:
         if: (matrix.arch != 'aarch64') && (matrix.channel != 'nightly')
         run: cargo test --verbose --target ${{ matrix.arch }}-pc-windows-${{ matrix.variant }}
       - name: Lint
-        run: cargo clippy --all-targets --no-deps -- -D warnings
+        # unknown-lints permits fixing lints on nightly without breaking stable
+        run: cargo clippy --all-targets --no-deps -- -D warnings -A unknown-lints

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -135,7 +135,14 @@ impl OpenOptionsImpl {
         self._open_at(d, path, flags)
     }
 
-    #[cfg(not(any(target_os = "aix", target_os = "dragonfly", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd")))]
+    #[cfg(not(any(
+        target_os = "aix",
+        target_os = "dragonfly",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
     pub fn open_path_at(&self, d: &File, path: &Path) -> Result<File> {
         let flags =
             libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_PATH | libc::O_CLOEXEC | libc::O_NOCTTY;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -314,6 +314,10 @@ unsafe impl<'a> Send for ReadDirImpl<'a> where Box<libc::DIR>: Send {}
 unsafe impl<'a> Sync for ReadDirImpl<'a> where Box<libc::DIR>: Sync {}
 
 impl<'a> ReadDirImpl<'a> {
+    // The code doesn't use the mutable value, but that is due to the value
+    // being a simple int passed to the kernel. The kernel does change global
+    // state, so the mutable ref is entirely appropriate.
+    #[allow(clippy::needless_pass_by_ref_mut)]
     pub fn new(dir_file: &'a mut File) -> Result<Self> {
         // closedir closes the FD; make a new one that we can close when done with.
         let new_fd =


### PR DESCRIPTION
The lint would be useful in any pure-rust layer, but as this is interfacing with the operating system, clippy has it wrong.