### PR TITLE
Remove unsupported open_path_at() operation on illumos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "fs_at"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aligned",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "fs_at"
 readme = "README.md"
 repository = "https://github.com/rbtcollins/fs_at.git"
 rust-version = "1.63.0"
-version = "0.1.9"
+version = "0.1.10"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,8 @@ impl OpenOptions {
     /// Unix: sets O_NOFOLLOW | O_PATH. Many operations on the file handle are
     /// restricted.
     ///
-    /// AIX, DragonFlyBSD, iOS, MacOSX, NetBSD, and OpenBSD: Not implemented as O_PATH is not defined.
+    /// AIX, DragonFlyBSD, iOS, MacOSX, NetBSD, OpenBSD, and illumos: Not
+    /// implemented as O_PATH is not defined.
     #[cfg(not(any(
         target_os = "aix",
         target_os = "dragonfly",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,15 @@ impl OpenOptions {
     /// restricted.
     ///
     /// AIX, DragonFlyBSD, iOS, MacOSX, NetBSD, and OpenBSD: Not implemented as O_PATH is not defined.
-    #[cfg(not(any(target_os = "aix", target_os = "dragonfly", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd")))]
+    #[cfg(not(any(
+        target_os = "aix",
+        target_os = "dragonfly",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "illumos"
+    )))]
     pub fn open_path_at<P: AsRef<Path>>(&self, d: &File, p: P) -> Result<File> {
         self._impl
             .open_path_at(d, OpenOptions::ensure_rootless(p.as_ref())?)
@@ -521,7 +529,12 @@ pub mod testsupport;
 
 #[cfg(test)]
 mod tests {
-    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "netbsd")))]
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "netbsd",
+        target_os = "illumos"
+    )))]
     use std::path::Path;
     use std::{
         ffi::OsStr,
@@ -1216,7 +1229,15 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(not(any(target_os = "aix", target_os = "dragonfly", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd")))]
+    #[cfg(not(any(
+        target_os = "aix",
+        target_os = "dragonfly",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "illumos"
+    )))]
     #[test]
     fn open_path_at() -> Result<()> {
         let (_tmp, parent_dir, _pathname) = setup()?;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -141,7 +141,8 @@ impl OpenOptionsImpl {
         target_os = "ios",
         target_os = "macos",
         target_os = "netbsd",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_os = "illumos"
     )))]
     pub fn open_path_at(&self, d: &File, path: &Path) -> Result<File> {
         let flags =


### PR DESCRIPTION
Illumos doesn't have an `O_PATH` flag, so I added it to the list of OSes not supported by the `open_path_at()`.