### PR TITLE
chore: upgrade publish-action to v0.4.5

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,23 +17,8 @@ jobs:
       - name: checkout
         uses: actions/checkout@master
 
-      # Use caching to speed up your build
-      - name: Cache publish-action bin
-        id: cache-publish-action
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-publish-action
-        with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-v0.1.13
-
-      # install publish-action by cargo in github action
-      - name: Install publish-action
-        if: steps.cache-publish-action.outputs.cache-hit != 'true'
-        run: cargo install publish-action --version=0.1.13
-
-      - name: Publish to cargo
-        run: publish-action
+      - name: Run publish-action
+        uses: tu6ge/publish-action@v0.4.5
         env:
           # This can help you tagging the github repository
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The new version is more fast than the old version