### PR TITLE
Disable `open_path_at()` API on GNU/Hurd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,11 +324,12 @@ impl OpenOptions {
     /// Unix: sets O_NOFOLLOW | O_PATH. Many operations on the file handle are
     /// restricted.
     ///
-    /// AIX, DragonFlyBSD, iOS, MacOSX, NetBSD, OpenBSD, and illumos: Not
-    /// implemented as O_PATH is not defined.
+    /// AIX, DragonFlyBSD, GNU/Hurd, iOS, MacOSX, NetBSD, OpenBSD, and illumos:
+    /// Not implemented as O_PATH is not defined.
     #[cfg(not(any(
         target_os = "aix",
         target_os = "dragonfly",
+        target_os = "hurd",
         target_os = "ios",
         target_os = "macos",
         target_os = "netbsd",

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -139,6 +139,7 @@ impl OpenOptionsImpl {
     #[cfg(not(any(
         target_os = "aix",
         target_os = "dragonfly",
+        target_os = "hurd",
         target_os = "ios",
         target_os = "macos",
         target_os = "netbsd",


### PR DESCRIPTION
`O_PATH` is not implemented on the Hurd.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rbtcollins/fs_at/205)
<!-- Reviewable:end -->
