### PR TITLE
Expose file type hints from directory entries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,22 +473,29 @@ impl Iterator for ReadDir<'_> {
 
 /// The returned type for each entry found by [`read_dir`].
 ///
-/// Each entry represents a single entry inside the directory. Platforms that
-/// provide rich metadata may in future expose this through methods or extension
-/// traits on DirEntry.
+/// Each entry represents a single entry inside the directory. Metadata returned
+/// from a directory listing is inherently racy: presuming that what was a dir,
+/// or symlink etc when the directory was listed, will still be the same when
+/// opened is fallible. [`file_type_hint()`] exposes metadata already returned by
+/// the directory listing without performing additional IO, but callers must
+/// handle the entry changing before a subsequent operation.
 ///
-/// For now however, only the [`name()`] is exposed. This does not imply any
-/// additional IO for most workloads: metadata returned from a directory listing
-/// is inherently racy: presuming that what was a dir, or symlink etc when the
-/// directory was listed, will still be the same when opened is fallible.
-/// Instead, use open_at to open the contents, and then process based on the
-/// type of content found.
+/// [`file_type_hint()`]: DirEntry::file_type_hint
 #[derive(Debug)]
 pub struct DirEntry {
     _impl: DirEntryImpl,
 }
 
 impl DirEntry {
+    /// Returns the file type hint supplied by the directory listing.
+    ///
+    /// This method performs no additional IO. `None` means that the platform or
+    /// filesystem did not supply a useful hint. The hint may be stale by the
+    /// time the entry is acted upon.
+    pub fn file_type_hint(&self) -> Option<FileTypeHint> {
+        self._impl.file_type_hint()
+    }
+
     pub fn name(&self) -> &OsStr {
         self._impl.name()
     }
@@ -499,6 +506,16 @@ impl DirEntry {
 /// See [`ReadDir`] and [`DirEntry`] for details.
 pub fn read_dir(d: &mut File) -> Result<ReadDir> {
     ReadDir::new(d)
+}
+
+/// A file type hint returned as part of a directory listing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum FileTypeHint {
+    /// The entry was reported as a directory.
+    Directory,
+    /// The entry was reported as a known non-directory type.
+    NonDirectory,
 }
 
 /// File kind indicator
@@ -1117,6 +1134,44 @@ mod tests {
         assert!(dir_present(&children, OsStr::new("1")), "{children:?}");
         assert!(dir_present(&children, OsStr::new("2")), "{children:?}");
         assert!(dir_present(&children, OsStr::new("child")), "{children:?}");
+        #[cfg(any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ))]
+        {
+            let file = children.iter().find(|entry| entry.name() == "1").unwrap();
+            let directory = children
+                .iter()
+                .find(|entry| entry.name() == "child")
+                .unwrap();
+            assert_eq!(
+                Some(crate::FileTypeHint::NonDirectory),
+                file.file_type_hint()
+            );
+            assert_eq!(
+                Some(crate::FileTypeHint::Directory),
+                directory.file_type_hint()
+            );
+        }
+        #[cfg(not(any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "ios",
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        )))]
+        assert!(children
+            .iter()
+            .all(|entry| entry.file_type_hint().is_none()));
 
         {
             let mut child = OpenOptions::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1134,44 +1134,19 @@ mod tests {
         assert!(dir_present(&children, OsStr::new("1")), "{children:?}");
         assert!(dir_present(&children, OsStr::new("2")), "{children:?}");
         assert!(dir_present(&children, OsStr::new("child")), "{children:?}");
-        #[cfg(any(
-            target_os = "android",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "ios",
-            target_os = "linux",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))]
-        {
-            let file = children.iter().find(|entry| entry.name() == "1").unwrap();
-            let directory = children
-                .iter()
-                .find(|entry| entry.name() == "child")
-                .unwrap();
-            assert_eq!(
-                Some(crate::FileTypeHint::NonDirectory),
-                file.file_type_hint()
-            );
-            assert_eq!(
-                Some(crate::FileTypeHint::Directory),
-                directory.file_type_hint()
-            );
-        }
-        #[cfg(not(any(
-            target_os = "android",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "ios",
-            target_os = "linux",
-            target_os = "macos",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )))]
-        assert!(children
+        let file = children.iter().find(|entry| entry.name() == "1").unwrap();
+        let directory = children
             .iter()
-            .all(|entry| entry.file_type_hint().is_none()));
+            .find(|entry| entry.name() == "child")
+            .unwrap();
+        assert!(matches!(
+            file.file_type_hint(),
+            None | Some(crate::FileTypeHint::NonDirectory)
+        ));
+        assert!(matches!(
+            directory.file_type_hint(),
+            None | Some(crate::FileTypeHint::Directory)
+        ));
 
         {
             let mut child = OpenOptions::default()

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -421,6 +421,8 @@ impl DirEntryImpl {
     }
 }
 
+// Access d_type only where libc::dirent is known to expose it; unlisted targets
+// conservatively return no hint.
 cfg_if::cfg_if! {
     if #[cfg(any(
         target_os = "android",

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -421,8 +421,8 @@ impl DirEntryImpl {
     }
 }
 
-// Access d_type only where libc::dirent is known to expose it; unlisted targets
-// conservatively return no hint.
+// Access d_type only on targets where the minimum supported libc crate version
+// exposes it; unlisted targets conservatively return no hint.
 cfg_if::cfg_if! {
     if #[cfg(any(
         target_os = "android",

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -378,33 +378,13 @@ impl Iterator for ReadDirImpl<'_> {
         nix::Error::clear();
         ptr::NonNull::new(unsafe { libc::readdir(dir) })
             .map(|e| {
-                #[cfg(any(
-                    target_os = "android",
-                    target_os = "dragonfly",
-                    target_os = "freebsd",
-                    target_os = "ios",
-                    target_os = "linux",
-                    target_os = "macos",
-                    target_os = "netbsd",
-                    target_os = "openbsd"
-                ))]
-                let file_type_hint = file_type_hint_from_d_type(unsafe { e.as_ref().d_type });
-                #[cfg(not(any(
-                    target_os = "android",
-                    target_os = "dragonfly",
-                    target_os = "freebsd",
-                    target_os = "ios",
-                    target_os = "linux",
-                    target_os = "macos",
-                    target_os = "netbsd",
-                    target_os = "openbsd"
-                )))]
-                let file_type_hint = None;
+                let entry = unsafe { e.as_ref() };
+                let file_type_hint = file_type_hint(entry);
 
                 Ok(DirEntryImpl {
                     name: unsafe {
                         // Step one: C pointer to CStr - referenced data, length not known.
-                        let c_str = std::ffi::CStr::from_ptr(e.as_ref().d_name.as_ptr());
+                        let c_str = std::ffi::CStr::from_ptr(entry.d_name.as_ptr());
                         // Step two: OsStr: referenced data, length calcu;ated
                         let os_str = OsStr::from_bytes(c_str.to_bytes());
                         // Step three: owned copy
@@ -441,21 +421,55 @@ impl DirEntryImpl {
     }
 }
 
-#[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "linux",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-fn file_type_hint_from_d_type(d_type: u8) -> Option<FileTypeHint> {
-    match d_type {
-        libc::DT_UNKNOWN => None,
-        libc::DT_DIR => Some(FileTypeHint::Directory),
-        _ => Some(FileTypeHint::NonDirectory),
+cfg_if::cfg_if! {
+    if #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))] {
+        fn file_type_hint(entry: &libc::dirent) -> Option<FileTypeHint> {
+            file_type_hint_from_d_type(entry.d_type)
+        }
+
+        fn file_type_hint_from_d_type(d_type: u8) -> Option<FileTypeHint> {
+            match d_type {
+                libc::DT_UNKNOWN => None,
+                libc::DT_DIR => Some(FileTypeHint::Directory),
+                _ => Some(FileTypeHint::NonDirectory),
+            }
+        }
+
+        #[cfg(test)]
+        mod file_type_hint_tests {
+            #[test]
+            fn mapping() {
+                assert_eq!(
+                    None,
+                    super::file_type_hint_from_d_type(libc::DT_UNKNOWN)
+                );
+                assert_eq!(
+                    Some(crate::FileTypeHint::Directory),
+                    super::file_type_hint_from_d_type(libc::DT_DIR)
+                );
+                assert_eq!(
+                    Some(crate::FileTypeHint::NonDirectory),
+                    super::file_type_hint_from_d_type(libc::DT_REG)
+                );
+                assert_eq!(
+                    Some(crate::FileTypeHint::NonDirectory),
+                    super::file_type_hint_from_d_type(libc::DT_LNK)
+                );
+            }
+        }
+    } else {
+        fn file_type_hint(_entry: &libc::dirent) -> Option<FileTypeHint> {
+            None
+        }
     }
 }
 
@@ -471,33 +485,6 @@ mod tests {
     use test_log::test;
 
     use crate::{os::unix::OpenOptionsExt, testsupport::open_dir, OpenOptions};
-
-    #[cfg(any(
-        target_os = "android",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "ios",
-        target_os = "linux",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd"
-    ))]
-    #[test]
-    fn file_type_hint_mapping() {
-        assert_eq!(None, super::file_type_hint_from_d_type(libc::DT_UNKNOWN));
-        assert_eq!(
-            Some(crate::FileTypeHint::Directory),
-            super::file_type_hint_from_d_type(libc::DT_DIR)
-        );
-        assert_eq!(
-            Some(crate::FileTypeHint::NonDirectory),
-            super::file_type_hint_from_d_type(libc::DT_REG)
-        );
-        assert_eq!(
-            Some(crate::FileTypeHint::NonDirectory),
-            super::file_type_hint_from_d_type(libc::DT_LNK)
-        );
-    }
 
     #[test]
     fn mkdirat_mode() -> Result<()> {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -29,7 +29,7 @@ cfg_if::cfg_if! {
 use cvt::cvt_r;
 use libc::{c_int, mkdirat, mode_t};
 
-use crate::{LinkEntryType, OpenOptions, OpenOptionsWriteMode};
+use crate::{FileTypeHint, LinkEntryType, OpenOptions, OpenOptionsWriteMode};
 
 pub mod exports {
     pub use super::OpenOptionsExt;
@@ -378,6 +378,29 @@ impl Iterator for ReadDirImpl<'_> {
         nix::Error::clear();
         ptr::NonNull::new(unsafe { libc::readdir(dir) })
             .map(|e| {
+                #[cfg(any(
+                    target_os = "android",
+                    target_os = "dragonfly",
+                    target_os = "freebsd",
+                    target_os = "ios",
+                    target_os = "linux",
+                    target_os = "macos",
+                    target_os = "netbsd",
+                    target_os = "openbsd"
+                ))]
+                let file_type_hint = file_type_hint_from_d_type(unsafe { e.as_ref().d_type });
+                #[cfg(not(any(
+                    target_os = "android",
+                    target_os = "dragonfly",
+                    target_os = "freebsd",
+                    target_os = "ios",
+                    target_os = "linux",
+                    target_os = "macos",
+                    target_os = "netbsd",
+                    target_os = "openbsd"
+                )))]
+                let file_type_hint = None;
+
                 Ok(DirEntryImpl {
                     name: unsafe {
                         // Step one: C pointer to CStr - referenced data, length not known.
@@ -387,6 +410,7 @@ impl Iterator for ReadDirImpl<'_> {
                         // Step three: owned copy
                         os_str.to_os_string()
                     },
+                    file_type_hint,
                 })
             })
             .or_else(|| {
@@ -404,11 +428,34 @@ impl Iterator for ReadDirImpl<'_> {
 #[derive(Debug)]
 pub(crate) struct DirEntryImpl {
     name: OsString,
+    file_type_hint: Option<FileTypeHint>,
 }
 
 impl DirEntryImpl {
+    pub fn file_type_hint(&self) -> Option<FileTypeHint> {
+        self.file_type_hint
+    }
+
     pub fn name(&self) -> &OsStr {
         &self.name
+    }
+}
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
+fn file_type_hint_from_d_type(d_type: u8) -> Option<FileTypeHint> {
+    match d_type {
+        libc::DT_UNKNOWN => None,
+        libc::DT_DIR => Some(FileTypeHint::Directory),
+        _ => Some(FileTypeHint::NonDirectory),
     }
 }
 
@@ -424,6 +471,33 @@ mod tests {
     use test_log::test;
 
     use crate::{os::unix::OpenOptionsExt, testsupport::open_dir, OpenOptions};
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    #[test]
+    fn file_type_hint_mapping() {
+        assert_eq!(None, super::file_type_hint_from_d_type(libc::DT_UNKNOWN));
+        assert_eq!(
+            Some(crate::FileTypeHint::Directory),
+            super::file_type_hint_from_d_type(libc::DT_DIR)
+        );
+        assert_eq!(
+            Some(crate::FileTypeHint::NonDirectory),
+            super::file_type_hint_from_d_type(libc::DT_REG)
+        );
+        assert_eq!(
+            Some(crate::FileTypeHint::NonDirectory),
+            super::file_type_hint_from_d_type(libc::DT_LNK)
+        );
+    }
 
     #[test]
     fn mkdirat_mode() -> Result<()> {

--- a/src/win.rs
+++ b/src/win.rs
@@ -1364,6 +1364,10 @@ pub(crate) struct DirEntryImpl {
 }
 
 impl DirEntryImpl {
+    pub fn file_type_hint(&self) -> Option<crate::FileTypeHint> {
+        None
+    }
+
     pub fn name(&self) -> &OsStr {
         &self.name
     }


### PR DESCRIPTION
`readdir` already returns entry type metadata on many Unix platforms, but
`fs_at` currently discards it. Callers that only need to distinguish directories
from known non-directories must therefore issue another syscall or optimistically
try a directory operation.

This adds `DirEntry::file_type_hint() -> Option<FileTypeHint>`.
`FileTypeHint` distinguishes `Directory` from `NonDirectory`; `None` means the
platform or filesystem did not provide a useful hint. The API documents that the
value is syscall-free and inherently racy, so callers must still handle the entry
changing before they act on it.

On supported Unix targets, the implementation copies `d_type` while the
`readdir` buffer is valid. `DT_UNKNOWN` maps to `None`, and access to `d_type`
and `DT_*` constants is protected by a positive target whitelist. Other Unix
targets, including AIX, illumos, and Solaris, compile without referencing those
members and return `None`. Windows remains behaviorally unchanged and also
returns `None`.

This is the upstream prerequisite for
[XAMPPRocky/remove_dir_all#89](https://github.com/XAMPPRocky/remove_dir_all/issues/89),
which will use the hint to avoid unnecessary `openat` calls on known
non-directories.

Tests cover raw `d_type` mapping and hints returned by `read_dir`. The change was
checked with Rust 1.71 tests and clippy, plus compile-only checks for illumos,
Solaris, and Windows.

Fixes #13.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rbtcollins/fs_at/221)
<!-- Reviewable:end -->
